### PR TITLE
Update circle.yml

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -17,5 +17,5 @@ test:
         timeout: 60
     - cd ember && ./node_modules/ember-cli/bin/ember test:
         timeout: 60
-    - cd django && codecov --token=4568dab7-185c-4039-aa72-00d046a85b75:
+    - cd django && codecov --token=4568dab7-185c-4039-aa72-00d046a85b75 --dir=django:
         timeout: 60


### PR DESCRIPTION
> I noticed the [reports](http://codecov.io/github/FreeMusicNinja/freemusic.ninja?ref=a76cdd7c719df6d7f675cc4b82fb6806cd56fed2) do not have he correct file structure. They should be (for example) `django/users/models.py` **not** `users/models.py`

I've patched to server to allow `--dir=django` argument to append the extra directory name to the report.

If you have a better idea on how to handle this, I'm all ears. Thanks

> v0.3.4 via https://github.com/codecov/codecov-python/commit/9ba01ae897e611b21d09f68f98a8196b5e1d4924
