### PR TITLE
Retrieve user after successful login and display welcome

### DIFF
--- a/ember/app/controllers/application.js
+++ b/ember/app/controllers/application.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 
 export default Ember.Controller.extend({
-    needs: 'auth',
-    userName: Ember.computed.alias('controllers.auth.model.name'),
+    needs: ['auth'],
+    userNameBinding: 'controllers.auth.content.email'
 });

--- a/ember/app/routes/application.js
+++ b/ember/app/routes/application.js
@@ -5,7 +5,14 @@ export default Ember.Route.extend(ApplicationRouteMixin, {
   model: function () {
     if (this.get('session.isAuthenticated')) {
       var authController = this.controllerFor('auth');
-      authController.set('model', this.store.find('user', 'me'));
+      authController.set('content', this.store.find('user', 'me'));
     }
   },
+
+  actions: {
+    sessionAuthenticationSucceeded: function() {
+      var authController = this.controllerFor('auth');
+      authController.set('content', this.store.find('user', 'me'));
+    }
+  }
 });

--- a/ember/app/templates/application.hbs
+++ b/ember/app/templates/application.hbs
@@ -30,9 +30,7 @@
       </ul>
       <ul class="nav navbar-nav navbar-right">
         {{#if session.isAuthenticated}}
-          {{#if userName}}
-            <li class="navbar-text">Welcome, {{userName}}</li>
-          {{/if}}
+          <li class="navbar-text">Welcome, {{userName}}</li>
           <li><a href="" {{ action 'invalidateSession' }}>Logout</a></li>
         {{else}}
           {{#link-li}}


### PR DESCRIPTION
I updated the Application Route to use content instead of model as this is preferred method.

In the Application Controller I created a binding for the users email (this should be replaced with Name once that content exists in the User Table) which is then referred to from within the application.hbs

The important part here is the `sessionAuthenticationSucceeded` action on the Application Route. This event is fired by ember-simple-auth for exactly this kind of scenario. On a reload of the page, the `model` hook would be responsible for the user retrieval, but when a fresh login occurs the `sessionAuthenticationSucceeded` action will handle the user retrieval. 
