### PR TITLE
Remove mock because we're using Python 3.4

### DIFF
--- a/django/artists/tests/test_api.py
+++ b/django/artists/tests/test_api.py
@@ -1,7 +1,7 @@
 import json
+from unittest.mock import patch
 
 from django.core.urlresolvers import reverse
-from mock import patch
 from rest_framework import status
 from rest_framework.test import APITestCase
 

--- a/django/dev-requirements.txt
+++ b/django/dev-requirements.txt
@@ -3,4 +3,3 @@
 coverage==3.7.1
 invoke==0.9.0
 Fabric==1.10.0
-mock==1.0.1

--- a/django/echonest/tests.py
+++ b/django/echonest/tests.py
@@ -1,7 +1,6 @@
 import json
 from unittest import TestCase
-
-from mock import patch
+from unittest.mock import patch
 
 from .models import SimilarResponse
 

--- a/django/similarities/tests/test_models.py
+++ b/django/similarities/tests/test_models.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
-from django.test import TestCase as DjangoTestCase
+from unittest.mock import patch
 
-from mock import patch
+from django.test import TestCase as DjangoTestCase
 
 from artists.models import Artist
 from .. import models

--- a/django/similarities/tests/test_utils.py
+++ b/django/similarities/tests/test_utils.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
-from django.test import TestCase as DjangoTestCase
+from unittest.mock import patch, call
 
-from mock import patch, call
+from django.test import TestCase as DjangoTestCase
 
 from artists.models import Artist
 from echonest.models import SimilarResponse

--- a/django/users/tests/test_models.py
+++ b/django/users/tests/test_models.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
+from unittest.mock import patch
 
 from django.test import TestCase as DjangoTestCase
-from mock import patch
 from rest_framework.authtoken.models import Token
 
 from .. import models


### PR DESCRIPTION
Python 3.4 includes mock in the standard library as `unittest.mock` because it's awesome.

:boom:
:rainbow:
