### PR TITLE
Fix mysteriously broken codecov usage

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -19,5 +19,5 @@ test:
         timeout: 60
     - cd django && coveralls:
         timeout: 60
-    - cd django && codecov --path=django:
+    - cd django && codecov:
         timeout: 60


### PR DESCRIPTION
It used to work fine, I think.
