### PR TITLE
Fix bootstrap pinning

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
     "ember-simple-auth": "0.6.7"
   },
   "devDependencies": {
-    "bootstrap-sass-official": "v3.2.0+2",
+    "bootstrap-sass-official": "3.2.0+2",
     "jquery-mockjax": "~1.6.0"
   }
 }


### PR DESCRIPTION
@treyhunner, this is one of the things that annoys me about bower. It uses the `bower_components` directory like a cache, meaning it doesn't clean up. If you delete your `bower_components` directory and rerun `npm install` and `ember test` you'll see the same behavior as the CI server.

Fixes #65
